### PR TITLE
Change base image to iojs slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,20 @@
-FROM iojs:onbuild
+FROM iojs:2-slim
+
+RUN apt-get update -qyy \
+  && apt-get install -qyy \
+    git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
 RUN npm i sematext/spm-agent-docker -g
-ADD ./run.sh /run.sh
+COPY ./run.sh /run.sh
 RUN chmod +x /run.sh
 EXPOSE 9000
 CMD /run.sh


### PR DESCRIPTION
This small change downsizes the image to 410.4 MB. With a bit more work it can be reduced even further.
